### PR TITLE
[refactor] persistance layer 추상화 리팩토링

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -64,6 +64,9 @@
 		320047DE2CFE9E0400D08B6D /* Extension + UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047DD2CFE9DFB00D08B6D /* Extension + UIApplication.swift */; };
 		3200480C2CFF0FB400D08B6D /* ProfileDropAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200480B2CFF0FA600D08B6D /* ProfileDropAnimation.swift */; };
 		320522BE2D0181A800F1677C /* ImageCacheable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320522BD2D0181A700F1677C /* ImageCacheable.swift */; };
+		3284D34E2D2F941C000ABC04 /* DataStoragable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3284D34D2D2F9417000ABC04 /* DataStoragable.swift */; };
+		3284D34F2D2F941C000ABC04 /* DataStoragable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3284D34D2D2F9417000ABC04 /* DataStoragable.swift */; };
+		3284D3502D2F941C000ABC04 /* DataStoragable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3284D34D2D2F9417000ABC04 /* DataStoragable.swift */; };
 		32A7563C2D00398100965F0A /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A7563B2D00397D00965F0A /* CacheManager.swift */; };
 		32A7563D2D00398100965F0A /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A7563B2D00397D00965F0A /* CacheManager.swift */; };
 		32A7563E2D00398100965F0A /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A7563B2D00397D00965F0A /* CacheManager.swift */; };
@@ -312,6 +315,7 @@
 		320047DD2CFE9DFB00D08B6D /* Extension + UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + UIApplication.swift"; sourceTree = "<group>"; };
 		3200480B2CFF0FA600D08B6D /* ProfileDropAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDropAnimation.swift; sourceTree = "<group>"; };
 		320522BD2D0181A700F1677C /* ImageCacheable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheable.swift; sourceTree = "<group>"; };
+		3284D34D2D2F9417000ABC04 /* DataStoragable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoragable.swift; sourceTree = "<group>"; };
 		32A7563B2D00397D00965F0A /* CacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheManager.swift; sourceTree = "<group>"; };
 		9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnBoardingPage.swift; sourceTree = "<group>"; };
 		9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestUserInfoRemoteUseCase.swift; sourceTree = "<group>"; };
@@ -849,6 +853,7 @@
 		FD69B1B12CE3BC55009D71DC /* Persistence */ = {
 			isa = PBXGroup;
 			children = (
+				3284D34D2D2F9417000ABC04 /* DataStoragable.swift */,
 				32A7563B2D00397D00965F0A /* CacheManager.swift */,
 				320045342CF4353400D08B6D /* SNMFileManager.swift */,
 				FD69B1B42CE3BC79009D71DC /* UserDefaultsManager.swift */,
@@ -1888,6 +1893,7 @@
 				FD331A852CF33D0500F39426 /* SupabaseSessionResponse.swift in Sources */,
 				FD331A862CF33D0500F39426 /* SupabaseUserResponse.swift in Sources */,
 				FD331A872CF33D0500F39426 /* SupabaseRefreshResponse.swift in Sources */,
+				3284D34F2D2F941C000ABC04 /* DataStoragable.swift in Sources */,
 				FD331A882CF33D0500F39426 /* SupabaseTokenRequest.swift in Sources */,
 				FD331A892CF33D0500F39426 /* SupabaseDatabaseManager.swift in Sources */,
 				FD331A8A2CF33D0500F39426 /* SupabaseDatabaseRequest.swift in Sources */,
@@ -1970,6 +1976,7 @@
 				320047B62CFCB8D000D08B6D /* EventConstant.swift in Sources */,
 				3200441C2CE48C5C00D08B6D /* MPCAdvertiser.swift in Sources */,
 				FD880B5A2CECE8FC0093BEB9 /* SNMLogger.swift in Sources */,
+				3284D3502D2F941C000ABC04 /* DataStoragable.swift in Sources */,
 				A2F825D12CDF4BA6000C5419 /* HomeViewController.swift in Sources */,
 				A2BA1BA92CF34A6A0080575A /* RequestMateListUseCase.swift in Sources */,
 				FD5134232CEC2BDE002E76F3 /* Routable.swift in Sources */,
@@ -2099,6 +2106,7 @@
 				320045352CF4353900D08B6D /* SNMFileManager.swift in Sources */,
 				3200453A2CF43F3800D08B6D /* FileManagerTest.swift in Sources */,
 				FD69B1C42CE3BCE4009D71DC /* KeychainManager.swift in Sources */,
+				3284D34E2D2F941C000ABC04 /* DataStoragable.swift in Sources */,
 				FD69B1CD2CE3E9BB009D71DC /* KeychainTests.swift in Sources */,
 				32A7563E2D00398100965F0A /* CacheManager.swift in Sources */,
 			);

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Router/ProfileCreateRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Router/ProfileCreateRouter.swift
@@ -33,7 +33,7 @@ extension ProfileCreateRouter: ProfileCreateBuildable {
         let saveUserInfoUseCase: SaveUserInfoUseCase =
         SaveUserInfoUseCaseImpl(
             localDataManager: LocalDataManager(),
-            imageManager: SNMFileManager()
+            imageManager: SNMFileManager(fileType: .image)
         )
         let saveProfileImageUseCase: SaveProfileImageUseCase =
         SaveProfileImageUseCaseImpl(

--- a/SniffMeet/SniffMeet/Source/Home/EditProfile/Router/ProfileEditRoutable.swift
+++ b/SniffMeet/SniffMeet/Source/Home/EditProfile/Router/ProfileEditRoutable.swift
@@ -27,7 +27,7 @@ extension ProfileEditRouter: ProfileEditBuildable {
     static func createProfileEditModule(userInfo: UserInfo) -> UIViewController {
         let saveUserInfoUseCase: SaveUserInfoUseCase = SaveUserInfoUseCaseImpl(
             localDataManager: LocalDataManager(),
-            imageManager: SNMFileManager()
+            imageManager: SNMFileManager(fileType: .image)
         )
         let updateUserInfoRemoteUseCase: UpdateUserInfoUseCase = UpdateUserInfoUseCaseImpl()
         let saveProfileImageUseCase: SaveProfileImageUseCase = SaveProfileImageUseCaseImpl(
@@ -44,7 +44,7 @@ extension ProfileEditRouter: ProfileEditBuildable {
                 saveProfileImageUseCase: saveProfileImageUseCase,
                 loadUserInfoUseCase: LoadUserInfoUseCaseImpl(
                 dataLoadable: LocalDataManager(),
-                imageManageable: SNMFileManager()
+                imageManageable: SNMFileManager(fileType: .image)
             )
         )
         let presenter: ProfileEditPresentable & ProfileEditInteractorOutput =

--- a/SniffMeet/SniffMeet/Source/Home/Main/HomeModuleBuilder.swift
+++ b/SniffMeet/SniffMeet/Source/Home/Main/HomeModuleBuilder.swift
@@ -14,7 +14,7 @@ enum HomeModuleBuilder {
         let interactor = HomeInteractor(
             loadUserInfoUseCase: LoadUserInfoUseCaseImpl(
                 dataLoadable: LocalDataManager(),
-                imageManageable: SNMFileManager()
+                imageManageable: SNMFileManager(fileType: .image)
             ),
             checkFirstLaunchUseCase: CheckFirstLaunchUseCaseImpl(
                 userDefaultsManager: UserDefaultsManager.shared

--- a/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
@@ -16,7 +16,7 @@ final class ImageNSCacheManager {
     static let shared = ImageNSCacheManager()
     
     private let cache: NSCache<NSString, CacheableImage>
-    private let fileManager: FileManageable
+    private let fileManager: any FileManagable
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
     
@@ -28,7 +28,7 @@ final class ImageNSCacheManager {
 
     private init(
         cache: NSCache<NSString, CacheableImage> = NSCache<NSString, CacheableImage>(),
-        fileManager: FileManageable = SNMFileManager())
+        fileManager: any FileManagable = SNMFileManager(fileType: .data))
     {
         self.cache = cache
         self.fileManager = fileManager
@@ -42,7 +42,7 @@ final class ImageNSCacheManager {
     func saveDiskCache(urlString: String, cacheableImage: CacheableImage) {
         do {
             let data = try encoder.encode(cacheableImage)
-            try fileManager.set(data: data, forKey: urlString)
+            try fileManager.set(value: data, forKey: urlString)
         } catch {
             SNMLogger.error("CacheManager-saveDiskCache: \(error.localizedDescription) ")
         }
@@ -54,8 +54,7 @@ final class ImageNSCacheManager {
     
     func imageFromDiskCache(urlString: String) -> CacheableImage? {
         do {
-            let data = try fileManager.fetch(forKey: urlString)
-            guard let data else { return nil }
+            let data = try fileManager.get(forKey: urlString)
             return try? decoder.decode(CacheableImage.self, from: data)
         } catch {
             SNMLogger.error("CacheManager-imageFromDiskCache: \(error.localizedDescription) ")

--- a/SniffMeet/SniffMeet/Source/Persistence/DataStoragable.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/DataStoragable.swift
@@ -1,9 +1,8 @@
 //
-//  DataStorageable.swift
+//  DataStoragable.swift
 //  SniffMeet
 //
 //  Created by 윤지성 on 1/9/25.
-//
 //
 import Foundation
 

--- a/SniffMeet/SniffMeet/Source/Persistence/DataStorageable.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/DataStorageable.swift
@@ -1,0 +1,26 @@
+//
+//  DataStorageable.swift
+//  SniffMeet
+//
+//  Created by 윤지성 on 1/9/25.
+//
+//
+import Foundation
+
+protocol DataStorageManagable {
+    associatedtype StoredType: Codable
+    func get(forKey key: String) throws -> StoredType
+    func set(value: StoredType, forKey key: String) throws
+    func delete(forKey key: String) throws
+}
+
+enum FileType {
+    case data
+    case image
+}
+
+protocol FileManagable: DataStorageManagable where StoredType == Data {
+    var fileType: FileType { get } // managing할 파일의 타입을 지정합니다.
+}
+
+protocol TokenManagable: DataStorageManagable where StoredType == String {}

--- a/SniffMeet/SniffMeet/Source/Persistence/KeychainManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/KeychainManager.swift
@@ -4,18 +4,9 @@
 //
 //  Created by sole on 11/7/24.
 //
-
 import Foundation
 
-protocol KeychainManagable {
-    func get(forKey: String) throws -> String
-    func set(value: String, forKey: String) throws
-    func delete(forKey: String) throws
-}
-
-/// Keychain에 접근할 수 있는 싱글톤 인스턴스입니다.
-/// key, value 타입은 String으로 한정합니다.
-final class KeychainManager: KeychainManagable {
+final class KeychainManager: TokenManagable {
     private init() {}
 
     func get(forKey key: String) throws -> String {

--- a/SniffMeet/SniffMeet/Source/Persistence/SNMFileManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/SNMFileManager.swift
@@ -6,26 +6,22 @@
 //
 import Foundation
 
-protocol ImageManagable {
-    func image(forKey: String) throws -> Data?
-    func setImage(imageData: Data, forKey: String) throws
-    func deleteImage(forKey: String) throws
-}
-protocol FileManageable {
-    func fetch(forKey: String) throws -> Data?
-    func set(data: Data, forKey: String) throws
-    func delete(forKey: String) throws
-}
-
-struct SNMFileManager: FileManageable {
+struct SNMFileManager: FileManagable {
+    var fileType: FileType
+    
     private var fileManager: FileManager { FileManager.default }
     private var documentsDir: URL? {
         fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
     }
+    private func fullURL(for fileName: String) -> URL? {
+        guard fileType == .data else {
+            return documentsDir?.appendingPathComponent(fileName)
+        }
+        return documentsDir?.appendingPathComponent(fileName, conformingTo: .jpeg)
+       }
     
     func fileExists(forKey path: String) -> Bool {
-        guard let documentsDir else { return false }
-        let fileURL = documentsDir.appendingPathComponent(path, conformingTo: .png)
+        guard let fileURL = fullURL(for: path) else { return false }
         if #available(iOS 16.0, *) {
             return fileManager.fileExists(atPath: fileURL.path())
         } else {
@@ -34,70 +30,29 @@ struct SNMFileManager: FileManageable {
     }
     
     /// key 값은 Environment.FileManagerKey를 이용하시면 됩니다.
-    func fetch(forKey: String) throws -> Data? {
-        guard let documentsDir else {
+    func get(forKey: String) throws -> Data {
+        guard let fileURL = fullURL(for: forKey) else {
             throw FileManagerError.directoryNotFound
         }
-        let fileURL = documentsDir.appendingPathComponent(forKey)
+        
         guard fileManager.fileExists(atPath: fileURL.path) else {
             throw FileManagerError.fileNotFound
         }
-        return try? Data(contentsOf: fileURL)
+        return try Data(contentsOf: fileURL)
     }
-    
-    func set(data: Data, forKey: String) throws {
-        guard let documentsDir else {
+
+    func set(value data: Data, forKey: String) throws {
+        guard let fileURL = fullURL(for: forKey) else {
             throw FileManagerError.directoryNotFound
         }
-        let fileURL = documentsDir.appendingPathComponent(forKey)
-        do {
-            try data.write(to: fileURL)
-        } catch {
-            SNMLogger.log(error.localizedDescription)
-            throw FileManagerError.writeError
-        }
+        try data.write(to: fileURL)
     }
     
     func delete(forKey: String) throws {
-        guard let documentsDir else {
+        guard let fileURL = fullURL(for: forKey) else {
             throw FileManagerError.directoryNotFound
         }
-        let fileURL = documentsDir.appendingPathComponent(forKey, conformingTo: .png)
-        do {
-            try fileManager.removeItem(at: fileURL)
-        } catch {
-            throw FileManagerError.deleteError
-        }
-    }
-}
-
-extension SNMFileManager: ImageManagable {
-    func image(forKey: String) throws -> Data? {
-        guard let documentsDir else {
-            throw FileManagerError.directoryNotFound
-        }
-        let fileURL = documentsDir.appendingPathComponent(forKey, conformingTo: .png)
-        guard fileManager.fileExists(atPath: fileURL.path) else {
-            throw FileManagerError.fileNotFound
-        }
-        return try? Data(contentsOf: fileURL)
-    }
-    
-    func setImage(imageData: Data, forKey: String) throws {
-        guard let documentsDir else {
-            throw FileManagerError.directoryNotFound
-        }
-        let fileURL = documentsDir.appendingPathComponent(forKey, conformingTo: .png)
-        do {
-            try imageData.write(to: fileURL)
-        } catch {
-            SNMLogger.log(error.localizedDescription)
-            throw FileManagerError.writeError
-        }
-    }
-    
-    func deleteImage(forKey: String) throws {
-        try delete(forKey: forKey)
+        try fileManager.removeItem(at: fileURL)
     }
 }
 

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/LoadUserInfoUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/LoadUserInfoUseCase.swift
@@ -11,9 +11,9 @@ protocol LoadUserInfoUseCase {
 
 struct LoadUserInfoUseCaseImpl: LoadUserInfoUseCase {
     private let dataLoadable: (any DataLoadable)
-    private let imageManageable: (any ImageManagable)
+    private let imageManageable: (any FileManagable)
 
-    init(dataLoadable: any DataLoadable, imageManageable: any ImageManagable) {
+    init(dataLoadable: any DataLoadable, imageManageable: any FileManagable) {
         self.dataLoadable = dataLoadable
         self.imageManageable = imageManageable
     }
@@ -21,7 +21,7 @@ struct LoadUserInfoUseCaseImpl: LoadUserInfoUseCase {
     func execute() throws -> UserInfo {
         var userInfo = try dataLoadable.loadData(forKey: Environment.UserDefaultsKey.dogInfo,
                                                  type: UserInfo.self)
-        userInfo.profileImage = try imageManageable.image(forKey: Environment.FileManagerKey.profileImage)
+        userInfo.profileImage = try imageManageable.get(forKey: Environment.FileManagerKey.profileImage)
         return userInfo
     }
 }

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/RegisterDeviceTokenUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/RegisterDeviceTokenUseCase.swift
@@ -12,9 +12,9 @@ protocol RegisterDeviceTokenUseCase {
 }
 
 struct RegisterDeviceTokenUseCaseImpl: RegisterDeviceTokenUseCase {
-    private let keychainManager: any KeychainManagable
+    private let keychainManager: any TokenManagable
 
-    init(keychainManager: any KeychainManagable) {
+    init(keychainManager: any TokenManagable) {
         self.keychainManager = keychainManager
     }
 

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/RemoteSaveDeviceTokenUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/RemoteSaveDeviceTokenUseCase.swift
@@ -13,12 +13,12 @@ protocol RemoteSaveDeviceTokenUseCase {
 
 struct RemoteSaveDeviceTokenUseCaseImpl: RemoteSaveDeviceTokenUseCase {
     private let jsonEncoder: JSONEncoder
-    private let keychainManager: any KeychainManagable
+    private let keychainManager: any TokenManagable
     private let remoteDBManager: any RemoteDatabaseManager
 
     init(
         jsonEncoder: JSONEncoder,
-        keychainManager: any KeychainManagable,
+        keychainManager: any TokenManagable,
         remoteDBManager: any RemoteDatabaseManager
     ) {
         self.jsonEncoder = jsonEncoder

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/SaveUserInfoUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/SaveUserInfoUseCase.swift
@@ -12,13 +12,13 @@ protocol SaveUserInfoUseCase {
 
 struct SaveUserInfoUseCaseImpl: SaveUserInfoUseCase {
     let localDataManager: DataStorable
-    let imageManager: ImageManagable
+    let imageManager: any FileManagable
     
     func execute(dog: UserInfo) throws {
         try localDataManager.storeData(data: dog, key: Environment.UserDefaultsKey.dogInfo)
         guard let imageData = dog.profileImage else { return }
         do {
-            try imageManager.setImage(imageData: imageData,
+            try imageManager.set(value: imageData,
                                       forKey: Environment.FileManagerKey.profileImage)
         } catch {
             SNMLogger.error("프로필 이미지 저장 실패: \(error.localizedDescription)")

--- a/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Router/RequestWalkRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Router/RequestWalkRouter.swift
@@ -53,7 +53,7 @@ extension RequestWalkRouter: RequestWalkBuildable {
         )
         let loadInfoUseCase: LoadUserInfoUseCase = LoadUserInfoUseCaseImpl(
             dataLoadable: LocalDataManager(),
-            imageManageable: SNMFileManager()
+            imageManageable: SNMFileManager(fileType: .image)
             )
         let view: RequestWalkViewable & UIViewController = RequestWalkViewController()
         let presenter: RequestWalkPresentable & RequestWalkInteractorOutput = RequestWalkPresenter()

--- a/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Router/RespondWalkRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Router/RespondWalkRouter.swift
@@ -48,7 +48,7 @@ RequestProfileImageUseCaseImpl(
         )
         let loadUserUseCase = LoadUserInfoUseCaseImpl(
             dataLoadable: LocalDataManager(),
-            imageManageable: SNMFileManager()
+            imageManageable: SNMFileManager(fileType: .image)
         )
 
         let view: RespondWalkViewable & UIViewController = RespondWalkViewController()


### PR DESCRIPTION
### 🔖  Issue Number

close #1

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
>  persistance layer의 추상화를 개선한다. 

### 데이터를 CRUD를 수행하는 상위 프로토콜 추가 
#### 개선 전
```swift
protocol ImageManagable {
    func image(forKey: String) throws -> Data?
    func setImage(imageData: Data, forKey: String) throws
    func deleteImage(forKey: String) throws
}

protocol FileManageable {
    func fetch(forKey: String) throws -> Data?
    func set(data: Data, forKey: String) throws
    func delete(forKey: String) throws
}

protocol KeychainManagable {
    func get(forKey: String) throws -> String
    func set(value: String, forKey: String) throws
    func delete(forKey: String) throws
}
```
#### 개선 후 
이러한 공통 동작을 상위 프로토콜로 추출하여 여러 하위 프로토콜에서 재사용할 수 있도록 수정했습니다. 
- FileManager는 Data 타입을 CRUD 하기 때문에 타입을 Data로 제한해두었고 TokenManager는 String으로 제한해 두었습니다. 
```swift
protocol DataStorageManagable {
    associatedtype StoredType: Codable
    func get(forKey key: String) throws -> StoredType
    func set(value: StoredType, forKey key: String) throws
    func delete(forKey key: String) throws
}

enum FileType {
    case data
    case image
}

protocol FileManagable: DataStorageManagable where StoredType == Data {
    var fileType: FileType { get } // managing할 파일의 타입을 지정합니다.
}

protocol TokenManagable: DataStorageManagable where StoredType == String {}

```

### 논의할 사항 
1. Userdefault 추상화 
 ```swift
protocol UserDefaultsManagable {
    func get<T>(forKey: String, type: T.Type) throws -> T where T: Decodable
    func set<T>(value: T, forKey: String) throws where T: Encodable
    func delete(forKey: String) throws
}

/// UserDefaults를 관리하는 클래스입니다.
/// 생성 시 userDefaults 파라미터에 아무것도 주입하지 않으면 standard를 기본으로 사용합니다.
final class UserDefaultsManager: UserDefaultsManagable {
    private let userDefaults: UserDefaults
    private let jsonEncoder: JSONEncoder
    private let jsonDecoder: JSONDecoder

    init(
        userDefaults: UserDefaults = .standard,
        jsonEncoder: JSONEncoder,
        jsonDecoder: JSONDecoder
    ) {
        self.userDefaults = userDefaults
        self.jsonEncoder = jsonEncoder
        self.jsonDecoder = jsonDecoder
    }
    ...
}
 ```
 - 현재 추상화는 특정 단일 타입에 대해서만 CRUD를 수행하는 persistance에 대해서만 상위 프로토콜을 두어 개선작업을 진행한 상태입니다. 
 - UserDefault는 여러 타입에 대해서 CRUD를 하는 동작에 대한 추상화가 적용되어 있습니다.  현재 UserDefaultManager 내부에서 인코딩 작업과 디코딩 작업을 진행하고 있어서 여러 타입을 받을 수 있습니다. 타입이 따로 정해져 있지 않기 때문에 DataStoragable 프로토콜을 적용할 수 없었습니다. 
 - 생각해보니 UserDefault가 수행하는 일에 대해서 저장소를 교체할 가능성이 적다고 생각하여 수행하는 일에 대한 추상화의 필요성이 낮다고 생각합니다!

