### PR TITLE
[feat] OSSignPoster 기능 추가

### DIFF
--- a/SniffMeet/SniffMeet/Source/Common/Util/SNMLogger.swift
+++ b/SniffMeet/SniffMeet/Source/Common/Util/SNMLogger.swift
@@ -9,6 +9,7 @@ import OSLog
 
 enum SNMLogger {
     private static let logger: Logger = Logger(subsystem: "SniffMeet", category: "SNMLogger")
+    private static let poster: OSSignposter = OSSignposter(logger: logger)
 
     /// debug 레벨에서 사용합니다.
     static func print(_ message: String...) {
@@ -22,5 +23,23 @@ enum SNMLogger {
     }
     static func log(level: OSLogType = .default, _ message: String...) {
         logger.log(level: level, "\(message.joined(separator: " "))")
+    }
+}
+
+// MARK: - SNMLogger+OSSignPoster
+
+extension SNMLogger {
+    /// 주의: 프로세스 bound를 넘어 사용하지 마세요
+    static func begin(name: StaticString) -> OSSignpostIntervalState {
+        let id = poster.makeSignpostID()
+        return poster.beginInterval(name, id: id)
+    }
+    /// 주의: 프로세스 bound를 넘어 사용하지 마세요
+    static func end(name: StaticString, state: OSSignpostIntervalState) {
+        poster.endInterval(name, state)
+    }
+    static func emitEvent(name: StaticString) {
+        let id = poster.makeSignpostID()
+        poster.emitEvent(name, id: id)
     }
 }


### PR DESCRIPTION
### 🔖  Issue Number

close #17 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- OSSignPoster 기능 추가 

측정하고 싶은 Scope에 아래와 같은 구문을 작성해주시면 됩니다. 
주의할 점은 begin과 end의 name이 반드시 동일해야 합니다. name이 동일하지 않으면 측정이 영원히 종료되지 않습니다. 

- 일반적인 메서드의 실행 결과를 알고 싶은 경우 

``` swift 
func test() {
// 프로파일링을 위해 추가되는 구문 
        let state = SNMLogger.begin(name: "test") // end와 동일 name 
        defer {
            SNMLogger.end(name: "test", state: state) // begin과 동일 name 
        }
       
// 원래 메서드 로직 
       print("test")
}

```

- 메서드 내 Task 블록(비동기 블록)의 실행 결과를 알고 싶은 경우 
아래 코드의 경우 Task 블록 내 로직만 프로파일링 합니다. 

``` swift 
func testTask() {
       print("testTask")

     Task { @MainActor in 
       // 프로파일링을 위해 추가되는 구문 
        let state = SNMLogger.begin(name: "test") // end와 동일 name 
        defer {
            SNMLogger.end(name: "test", state: state) // begin과 동일 name 
        }
       print("testTask2")
   }
}

```


