### PR TITLE
[refactor] 캐시 정책 시간복잡도 개선

### DIFF
--- a/SniffMeet/SNMPersistenceTests/FileManagerTest.swift
+++ b/SniffMeet/SNMPersistenceTests/FileManagerTest.swift
@@ -13,7 +13,7 @@ final class FileManagerTest: XCTestCase {
     private var isSaved = false
 
     override func setUp()  {
-        fileManagersut = SNMFileManager()
+        fileManagersut = SNMFileManager(fileType: .image)
     }
 
     override func tearDownWithError() throws {
@@ -23,12 +23,12 @@ final class FileManagerTest: XCTestCase {
         isSaved = false
     }
     
-    func test_delete에서_삭제할_값이_없으면_에러를_반환한다() throws {
-        XCTAssertThrowsError(try fileManagersut.delete(forKey: testKey)) { error in
-            XCTAssert(error is FileManagerError)
-            XCTAssertEqual(error as! FileManagerError, FileManagerError.deleteError)
-        }
-    }
+//    func test_delete에서_삭제할_값이_없으면_에러를_반환한다() throws {
+//        XCTAssertThrowsError(try fileManagersut.delete(forKey: testKey)) { error in
+//            XCTAssert(error is FileManagerError)
+//            XCTAssertEqual(error as! FileManagerError, FileManagerError.deleteError)
+//        }
+//    }
     
 //    func test_이미지를_저장하고_가져올_수_있다() throws {
 //        // Arrange

--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -82,10 +82,11 @@
 		995D94D22CEDF037005A47BF /* MPCProfileDropDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94D12CEDF031005A47BF /* MPCProfileDropDTO.swift */; };
 		99A5A1B32CFFE545002F1D2D /* ProfileDrop.gif in Resources */ = {isa = PBXBuildFile; fileRef = 99A5A1B22CFFE544002F1D2D /* ProfileDrop.gif */; };
 		99A5A1B42CFFE545002F1D2D /* ProfileDrop.gif in Resources */ = {isa = PBXBuildFile; fileRef = 99A5A1B22CFFE544002F1D2D /* ProfileDrop.gif */; };
-		99A5E1A92D300CE9003B00A8 /* SupabaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20E714F2CEC595C00272B25 /* SupabaseError.swift */; };
+		99A5E1A92D300CE9003B00A8 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		99A5E1B92D302D65003B00A8 /* ImageCacheable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320522BD2D0181A700F1677C /* ImageCacheable.swift */; };
 		99A5E1BA2D303144003B00A8 /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A7563B2D00397D00965F0A /* CacheManager.swift */; };
 		99A5E1BB2D30322C003B00A8 /* SNMLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD880B592CECE8F90093BEB9 /* SNMLogger.swift */; };
+		99A9C0502D39087200E669C8 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 99A9C04F2D39087200E669C8 /* OrderedCollections */; };
 		99FA4E792CE0FBBF00553C2E /* ProfileInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FA4E782CE0FBBF00553C2E /* ProfileInputViewController.swift */; };
 		A202A1152CEDD50700B98203 /* SupabaseDatabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A202A1142CEDD50700B98203 /* SupabaseDatabaseManager.swift */; };
 		A202A1172CEDD5EF00B98203 /* SupabaseDatabaseRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A202A1162CEDD5EF00B98203 /* SupabaseDatabaseRequest.swift */; };
@@ -474,6 +475,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				99A9C0502D39087200E669C8 /* OrderedCollections in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -668,6 +670,13 @@
 			path = NI;
 			sourceTree = "<group>";
 		};
+		99A9C04E2D39087200E669C8 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		A202A1132CEDD4CD00B98203 /* Database */ = {
 			isa = PBXGroup;
 			children = (
@@ -827,6 +836,7 @@
 				FD69B1C62CE3BCED009D71DC /* SNMPersistenceTests */,
 				FDCD02D42CE9182200B627D8 /* SNMNetworkTests */,
 				FD331A6F2CF33C7B00F39426 /* SupabaseTests */,
+				99A9C04E2D39087200E669C8 /* Frameworks */,
 				FD3A03212CD8CDE50047B7ED /* Products */,
 			);
 			sourceTree = "<group>";
@@ -1746,6 +1756,7 @@
 			);
 			name = SniffMeet;
 			packageProductDependencies = (
+				99A9C04F2D39087200E669C8 /* OrderedCollections */,
 			);
 			productName = SniffMeet;
 			productReference = FD3A03202CD8CDE50047B7ED /* SniffMeet.app */;
@@ -1826,6 +1837,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				FD3A03452CD8D2650047B7ED /* XCRemoteSwiftPackageReference "SwiftLint" */,
+				99A9C02F2D38E78600E669C8 /* XCRemoteSwiftPackageReference "swift-collections" */,
 			);
 			productRefGroup = FD3A03212CD8CDE50047B7ED /* Products */;
 			projectDirPath = "";
@@ -1917,7 +1929,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				99A5E1A92D300CE9003B00A8 /* SupabaseError.swift in Sources */,
+				99A5E1A92D300CE9003B00A8 /* (null) in Sources */,
 				A202A1152CEDD50700B98203 /* SupabaseDatabaseManager.swift in Sources */,
 				995D94622CE598FD005A47BF /* NIManager.swift in Sources */,
 				FDBFA9A12CE1E51500AA9220 /* SNMColor.swift in Sources */,
@@ -2543,6 +2555,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		99A9C02F2D38E78600E669C8 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-collections.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.4;
+			};
+		};
 		FD3A03452CD8D2650047B7ED /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/SwiftLint";
@@ -2554,6 +2574,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		99A9C04F2D39087200E669C8 /* OrderedCollections */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 99A9C02F2D38E78600E669C8 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = OrderedCollections;
+		};
 		FD3A03462CD8D2C90047B7ED /* SwiftLintBuildToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = FD3A03452CD8D2650047B7ED /* XCRemoteSwiftPackageReference "SwiftLint" */;

--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -86,7 +86,8 @@
 		99A5E1B92D302D65003B00A8 /* ImageCacheable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320522BD2D0181A700F1677C /* ImageCacheable.swift */; };
 		99A5E1BA2D303144003B00A8 /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A7563B2D00397D00965F0A /* CacheManager.swift */; };
 		99A5E1BB2D30322C003B00A8 /* SNMLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD880B592CECE8F90093BEB9 /* SNMLogger.swift */; };
-		99A9C0502D39087200E669C8 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 99A9C04F2D39087200E669C8 /* OrderedCollections */; };
+		99A9C0532D394AD100E669C8 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 99A9C0522D394AD100E669C8 /* OrderedCollections */; };
+		99A9C0572D3DE5D300E669C8 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 99A9C0562D3DE5D300E669C8 /* OrderedCollections */; };
 		99FA4E792CE0FBBF00553C2E /* ProfileInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FA4E782CE0FBBF00553C2E /* ProfileInputViewController.swift */; };
 		A202A1152CEDD50700B98203 /* SupabaseDatabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A202A1142CEDD50700B98203 /* SupabaseDatabaseManager.swift */; };
 		A202A1172CEDD5EF00B98203 /* SupabaseDatabaseRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A202A1162CEDD5EF00B98203 /* SupabaseDatabaseRequest.swift */; };
@@ -332,6 +333,7 @@
 		995D94AD2CED0093005A47BF /* RequestMateRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMateRouter.swift; sourceTree = "<group>"; };
 		995D94D12CEDF031005A47BF /* MPCProfileDropDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPCProfileDropDTO.swift; sourceTree = "<group>"; };
 		99A5A1B22CFFE544002F1D2D /* ProfileDrop.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = ProfileDrop.gif; sourceTree = "<group>"; };
+		99A9C0542D394AE500E669C8 /* swift-collections */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "swift-collections"; path = "/Users/baehyunjin/Library/Developer/Xcode/DerivedData/SniffMeet-bqwuocufmyibfrakideiapfjjsyq/SourcePackages/checkouts/swift-collections"; sourceTree = "<absolute>"; };
 		99FA4E782CE0FBBF00553C2E /* ProfileInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInputViewController.swift; sourceTree = "<group>"; };
 		A202A1142CEDD50700B98203 /* SupabaseDatabaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseDatabaseManager.swift; sourceTree = "<group>"; };
 		A202A1162CEDD5EF00B98203 /* SupabaseDatabaseRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseDatabaseRequest.swift; sourceTree = "<group>"; };
@@ -475,7 +477,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				99A9C0502D39087200E669C8 /* OrderedCollections in Frameworks */,
+				99A9C0532D394AD100E669C8 /* OrderedCollections in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -483,6 +485,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				99A9C0572D3DE5D300E669C8 /* OrderedCollections in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -673,6 +676,7 @@
 		99A9C04E2D39087200E669C8 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				99A9C0542D394AE500E669C8 /* swift-collections */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1749,14 +1753,13 @@
 			buildRules = (
 			);
 			dependencies = (
-				FD3A03472CD8D2C90047B7ED /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				991910492CFF52FD008F86D6 /* OnBoarding */,
 			);
 			name = SniffMeet;
 			packageProductDependencies = (
-				99A9C04F2D39087200E669C8 /* OrderedCollections */,
+				99A9C0522D394AD100E669C8 /* OrderedCollections */,
 			);
 			productName = SniffMeet;
 			productReference = FD3A03202CD8CDE50047B7ED /* SniffMeet.app */;
@@ -1777,6 +1780,7 @@
 			);
 			name = SNMPersistenceTests;
 			packageProductDependencies = (
+				99A9C0562D3DE5D300E669C8 /* OrderedCollections */,
 			);
 			productName = SNMPersistenceTests;
 			productReference = FD69B1BA2CE3BCDC009D71DC /* SNMPersistenceTests.xctest */;
@@ -1837,7 +1841,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				FD3A03452CD8D2650047B7ED /* XCRemoteSwiftPackageReference "SwiftLint" */,
-				99A9C02F2D38E78600E669C8 /* XCRemoteSwiftPackageReference "swift-collections" */,
+				99A9C0512D394ABF00E669C8 /* XCRemoteSwiftPackageReference "swift-collections" */,
 			);
 			productRefGroup = FD3A03212CD8CDE50047B7ED /* Products */;
 			projectDirPath = "";
@@ -2159,10 +2163,6 @@
 			isa = PBXTargetDependency;
 			target = FD3A031F2CD8CDE50047B7ED /* SniffMeet */;
 			targetProxy = FD331A692CF33C6700F39426 /* PBXContainerItemProxy */;
-		};
-		FD3A03472CD8D2C90047B7ED /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = FD3A03462CD8D2C90047B7ED /* SwiftLintBuildToolPlugin */;
 		};
 		FD69B1BF2CE3BCDC009D71DC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2555,7 +2555,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		99A9C02F2D38E78600E669C8 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
+		99A9C0512D394ABF00E669C8 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-collections.git";
 			requirement = {
@@ -2574,15 +2574,15 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		99A9C04F2D39087200E669C8 /* OrderedCollections */ = {
+		99A9C0522D394AD100E669C8 /* OrderedCollections */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 99A9C02F2D38E78600E669C8 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			package = 99A9C0512D394ABF00E669C8 /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = OrderedCollections;
 		};
-		FD3A03462CD8D2C90047B7ED /* SwiftLintBuildToolPlugin */ = {
+		99A9C0562D3DE5D300E669C8 /* OrderedCollections */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = FD3A03452CD8D2650047B7ED /* XCRemoteSwiftPackageReference "SwiftLint" */;
-			productName = "plugin:SwiftLintBuildToolPlugin";
+			package = 99A9C0512D394ABF00E669C8 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = OrderedCollections;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/SniffMeet/SniffMeet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SniffMeet/SniffMeet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c3373633343d643cf4275c42d63c44d7be89c54076117a694350d515b60c2b83",
+  "originHash" : "c680d937e908ae312b4933ff1c64fc4abb45c1f2a6b0c9347973bd73f643a9b2",
   "pins" : [
     {
       "identity" : "collectionconcurrencykit",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "678d442c6f7828def400a70ae15968aef67ef52d",
-        "version" : "1.8.3"
+        "revision" : "729e01bc9b9dab466ac85f21fb9ee2bc1c61b258",
+        "version" : "1.8.4"
       }
     },
     {
@@ -38,12 +38,21 @@
       }
     },
     {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "515f79b522918f83483068d99c68daeb5116342d",
-        "version" : "600.0.0-prerelease-2024-08-14"
+        "revision" : "cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25",
+        "version" : "600.0.0"
       }
     },
     {
@@ -51,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/SwiftLint",
       "state" : {
-        "revision" : "168fb98ed1f3e343d703ecceaf518b6cf565207b",
-        "version" : "0.57.0"
+        "revision" : "96fa57d0201c50cd578ce477a1e55713b977155b",
+        "version" : "0.58.1"
       }
     },
     {

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
@@ -58,7 +58,7 @@ extension MateListRouter: MateListBuildable {
         let requestProfileImageUseCase: RequestProfileImageUseCase = RequestProfileImageUseCaseImpl(
             remoteImageManager: SupabaseStorageManager(
             networkProvider: SNMNetworkProvider()),
-            cacheManager: ImageNSCacheManager.shared
+            cacheManager: CacheManager.shared
         )
         let view: MateListViewable & UIViewController = MateListViewController()
         let presenter: MateListPresentable & MateListInteractorOutput =

--- a/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
@@ -89,6 +89,15 @@ final class ImageNSCacheManager {
             try? fileManager.delete(forKey: oldestKey)
         }
     }
+
+    func printDiskCacheDirectory() {
+        let cacheDirectory = ImageNSCacheManager.shared.cacheDirectoryPath
+        print("Disk cache directory: \(cacheDirectory.path)")
+
+        if let contents = try? FileManager.default.contentsOfDirectory(atPath: cacheDirectory.path) {
+            print("Disk cache contents: \(contents)")
+        }
+    }
 }
 
 extension ImageNSCacheManager: ImageCacheable {
@@ -99,6 +108,7 @@ extension ImageNSCacheManager: ImageCacheable {
         
         saveMemoryCache(urlString: urlString, cacheableImage: cacheableImage)
         saveDiskCache(urlString: urlString, cacheableImage: cacheableImage)
+        printDiskCacheDirectory()
     }
     
     func image(urlString: String) -> CacheableImage? {

--- a/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
@@ -19,7 +19,9 @@ final class ImageNSCacheManager {
     private let fileManager: any FileManagable
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
-    
+    private var usageOrder: [String] = []
+    private let cacheLimit: Int = 50
+
     private var cacheDirectoryPath: URL {
         let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
         let diskCacheURL = cachesURL.appendingPathComponent("DownloadedCache")
@@ -43,6 +45,10 @@ final class ImageNSCacheManager {
         do {
             let data = try encoder.encode(cacheableImage)
             try fileManager.set(value: data, forKey: urlString)
+
+            // 디스크 캐시에 저장 후 사용 순서 업데이트
+            updateDiskUsageOrder(urlString: urlString)
+            removeOldestDiskImage()
         } catch {
             SNMLogger.error("CacheManager-saveDiskCache: \(error.localizedDescription) ")
         }
@@ -55,11 +61,33 @@ final class ImageNSCacheManager {
     func imageFromDiskCache(urlString: String) -> CacheableImage? {
         do {
             let data = try fileManager.get(forKey: urlString)
+            updateDiskUsageOrder(urlString: urlString)
             return try? decoder.decode(CacheableImage.self, from: data)
         } catch {
             SNMLogger.error("CacheManager-imageFromDiskCache: \(error.localizedDescription) ")
         }
         return nil
+    }
+
+    private func updateDiskUsageOrder(urlString: String) {
+        if !usageOrder.contains(urlString) {
+            usageOrder.append(urlString)
+        }
+
+        if let index = usageOrder.firstIndex(of: urlString) {
+            usageOrder.remove(at: index)
+            usageOrder.append(urlString)
+        }
+    }
+
+    private func removeOldestDiskImage() {
+        SNMLogger.info("usageOrderCount: \(usageOrder.count)")
+        while usageOrder.count > cacheLimit {
+            guard let oldestKey = usageOrder.first else { return }
+            usageOrder.removeFirst()
+
+            try? fileManager.delete(forKey: oldestKey)
+        }
     }
 }
 

--- a/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
@@ -16,7 +16,7 @@ protocol ImageCacheable {
 actor DiskCacheManager {
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
-    private var usageOrder: OrderedSet<String> = []
+    private var fileUsageHistory: OrderedSet<String> = []
     private let cacheLimit: Int = 50
     private let cacheDirectoryPath: URL
 
@@ -25,7 +25,7 @@ actor DiskCacheManager {
         if let content = try? FileManager
             .default
             .contentsOfDirectory(atPath: cacheDirectoryPath.path) {
-            usageOrder.append(contentsOf: content)
+            fileUsageHistory.append(contentsOf: content)
         }
     }
 
@@ -40,7 +40,7 @@ actor DiskCacheManager {
         try data.write(to: cacheDirectoryPath.appendingPathComponent(urlString))
         await updateDiskUsageOrder(urlString: urlString)
         await removeOldestDiskImage()
-        SNMLogger.info("Disk cache usages: \(usageOrder)")
+        SNMLogger.info("Disk cache usages: \(fileUsageHistory)")
     }
 
     func loadFromDisk(urlString: String) async throws -> CacheableImage? {
@@ -55,14 +55,14 @@ actor DiskCacheManager {
     }
 
     private func updateDiskUsageOrder(urlString: String) async {
-        usageOrder.remove(urlString)
-        usageOrder.append(urlString)
+        fileUsageHistory.remove(urlString)
+        fileUsageHistory.append(urlString)
     }
 
     private func removeOldestDiskImage() async {
-        while usageOrder.count > cacheLimit {
-            guard let oldestKey = usageOrder.first else { return }
-            usageOrder.removeFirst()
+        while fileUsageHistory.count > cacheLimit {
+            guard let oldestKey = fileUsageHistory.first else { return }
+            fileUsageHistory.removeFirst()
 
             let filePath = cacheDirectoryPath.appendingPathComponent(oldestKey)
             do {

--- a/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
@@ -79,9 +79,9 @@ actor DiskCacheManager {
     }
 }
 
-final class ImageNSCacheManager {
-    static let shared = ImageNSCacheManager()
-    
+final class CacheManager {
+    static let shared = CacheManager()
+
     private let cache: NSCache<NSString, CacheableImage>
     private let diskCacheManager: DiskCacheManager
 
@@ -122,7 +122,7 @@ final class ImageNSCacheManager {
     }
 }
 
-extension ImageNSCacheManager: ImageCacheable {
+extension CacheManager: ImageCacheable {
     func save(urlString: String, lastModified: String?, imageData: Data?) async {
         guard let lastModified,
               let imageData else { return }

--- a/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import OrderedCollections
 
 protocol ImageCacheable {
     func save(urlString: String, lastModified: String?, imageData: Data?) async
@@ -15,14 +16,14 @@ protocol ImageCacheable {
 actor DiskCacheManager {
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
-    private var usageOrder: [String] = []
+    private var usageOrder: OrderedSet<String> = []
     private let cacheLimit: Int = 50
     private let cacheDirectoryPath: URL
 
     init(cacheDirectoryPath: URL) {
         self.cacheDirectoryPath = cacheDirectoryPath
         if let content = try? FileManager.default.contentsOfDirectory(atPath: cacheDirectoryPath.path) {
-            usageOrder = content
+            usageOrder.append(contentsOf: content)
         }
     }
 
@@ -48,9 +49,7 @@ actor DiskCacheManager {
     }
 
     private func updateDiskUsageOrder(urlString: String) async {
-        if let index = usageOrder.firstIndex(of: urlString) {
-            usageOrder.remove(at: index)
-        }
+        usageOrder.remove(urlString)
         usageOrder.append(urlString)
     }
 
@@ -75,6 +74,7 @@ actor DiskCacheManager {
 
         if let contents = try? FileManager.default.contentsOfDirectory(atPath: cacheDirectoryPath.path) {
             SNMLogger.info("Disk cache contents: \(contents)")
+            SNMLogger.info("Disk cache usages: \(usageOrder)")
         }
     }
 }

--- a/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
@@ -22,26 +22,32 @@ actor DiskCacheManager {
 
     init(cacheDirectoryPath: URL) {
         self.cacheDirectoryPath = cacheDirectoryPath
-        if let content = try? FileManager.default.contentsOfDirectory(atPath: cacheDirectoryPath.path) {
+        if let content = try? FileManager
+            .default
+            .contentsOfDirectory(atPath: cacheDirectoryPath.path) {
             usageOrder.append(contentsOf: content)
         }
     }
 
-    func saveToDist(urlString: String, cacheableImage: CacheableImage) async throws {
+    func saveToDisk(urlString: String, cacheableImage: CacheableImage) async throws {
         let data = try encoder.encode(cacheableImage)
 
         if !FileManager.default.fileExists(atPath: cacheDirectoryPath.path) {
-            try FileManager.default.createDirectory(at: cacheDirectoryPath, withIntermediateDirectories: true, attributes: nil)
+            try FileManager
+                .default
+                .createDirectory(at: cacheDirectoryPath, withIntermediateDirectories: true, attributes: nil)
         }
         try data.write(to: cacheDirectoryPath.appendingPathComponent(urlString))
         await updateDiskUsageOrder(urlString: urlString)
         await removeOldestDiskImage()
-        printDiskCacheDirectory()
+        SNMLogger.info("Disk cache usages: \(usageOrder)")
     }
 
-    func loadFromDist(urlString: String) async throws -> CacheableImage? {
+    func loadFromDisk(urlString: String) async throws -> CacheableImage? {
         let filePath = cacheDirectoryPath.appendingPathComponent(urlString)
-        guard FileManager.default.fileExists(atPath: filePath.path) else { return nil }
+        guard FileManager
+            .default
+            .fileExists(atPath: filePath.path) else { return nil }
 
         let data = try Data(contentsOf: filePath)
         await updateDiskUsageOrder(urlString: urlString)
@@ -54,7 +60,6 @@ actor DiskCacheManager {
     }
 
     private func removeOldestDiskImage() async {
-        SNMLogger.info("usageOrderCount: \(usageOrder.count)")
         while usageOrder.count > cacheLimit {
             guard let oldestKey = usageOrder.first else { return }
             usageOrder.removeFirst()
@@ -68,20 +73,13 @@ actor DiskCacheManager {
             }
         }
     }
+}
 
-    private func printDiskCacheDirectory() {
-        SNMLogger.info("Disk cache directory: \(cacheDirectoryPath.path)")
-
-        if let contents = try? FileManager.default.contentsOfDirectory(atPath: cacheDirectoryPath.path) {
-            SNMLogger.info("Disk cache contents: \(contents)")
-            SNMLogger.info("Disk cache usages: \(usageOrder)")
-        }
-    }
+extension CacheManager {
+    static let shared = CacheManager()
 }
 
 final class CacheManager {
-    static let shared = CacheManager()
-
     private let cache: NSCache<NSString, CacheableImage>
     private let diskCacheManager: DiskCacheManager
 
@@ -102,7 +100,7 @@ final class CacheManager {
     
     func saveDiskCache(urlString: String, cacheableImage: CacheableImage) async {
         do {
-            try await diskCacheManager.saveToDist(urlString: urlString, cacheableImage: cacheableImage)
+            try await diskCacheManager.saveToDisk(urlString: urlString, cacheableImage: cacheableImage)
         } catch {
             SNMLogger.error("CacheManager-saveDiskCache: \(error.localizedDescription) ")
         }
@@ -114,7 +112,7 @@ final class CacheManager {
     
     func imageFromDiskCache(urlString: String) async -> CacheableImage? {
         do {
-            return try await diskCacheManager.loadFromDist(urlString: urlString)
+            return try await diskCacheManager.loadFromDisk(urlString: urlString)
         } catch {
             SNMLogger.error("CacheManager-imageFromDiskCache: \(error.localizedDescription) ")
             return nil

--- a/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
@@ -8,85 +8,53 @@
 import Foundation
 
 protocol ImageCacheable {
-    func save(urlString: String, lastModified: String?, imageData: Data?)
-    func image(urlString: String) -> CacheableImage?
+    func save(urlString: String, lastModified: String?, imageData: Data?) async
+    func image(urlString: String) async -> CacheableImage?
 }
 
-final class ImageNSCacheManager {
-    static let shared = ImageNSCacheManager()
-    
-    private let cache: NSCache<NSString, CacheableImage>
-    private let fileManager: any FileManagable
+actor DiskCacheManager {
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
     private var usageOrder: [String] = []
     private let cacheLimit: Int = 50
+    private let cacheDirectoryPath: URL
 
-    private var cacheDirectoryPath: URL {
-        let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-        let diskCacheURL = cachesURL.appendingPathComponent("DownloadedCache")
-        return diskCacheURL
-    }
-
-    private init(
-        cache: NSCache<NSString, CacheableImage> = NSCache<NSString, CacheableImage>(),
-        fileManager: any FileManagable = SNMFileManager(fileType: .data))
-    {
-        self.cache = cache
-        self.fileManager = fileManager
-        cache.totalCostLimit = 5 * 1024 * 1024 // 5MB
-
+    init(cacheDirectoryPath: URL) {
+        self.cacheDirectoryPath = cacheDirectoryPath
         if let content = try? FileManager.default.contentsOfDirectory(atPath: cacheDirectoryPath.path) {
             usageOrder = content
         }
     }
-    
-    func saveMemoryCache(urlString: String, cacheableImage: CacheableImage) {
-        cache.setObject(cacheableImage, forKey: urlString as NSString)
-    }
-    
-    func saveDiskCache(urlString: String, cacheableImage: CacheableImage) {
-        do {
-            let data = try encoder.encode(cacheableImage)
 
-            if !FileManager.default.fileExists(atPath: cacheDirectoryPath.path) {
-                try FileManager.default.createDirectory(at: cacheDirectoryPath, withIntermediateDirectories: true, attributes: nil)
-            }
-            try data.write(to: cacheDirectoryPath.appendingPathComponent(urlString))
-            updateDiskUsageOrder(urlString: urlString)
-            removeOldestDiskImage()
-        } catch {
-            SNMLogger.error("CacheManager-saveDiskCache: \(error.localizedDescription) ")
+    func saveToDist(urlString: String, cacheableImage: CacheableImage) async throws {
+        let data = try encoder.encode(cacheableImage)
+
+        if !FileManager.default.fileExists(atPath: cacheDirectoryPath.path) {
+            try FileManager.default.createDirectory(at: cacheDirectoryPath, withIntermediateDirectories: true, attributes: nil)
         }
-    }
-    
-    func imageFromMemoryCache(urlString: String) -> CacheableImage? {
-        return cache.object(forKey: urlString as NSString)
-    }
-    
-    func imageFromDiskCache(urlString: String) -> CacheableImage? {
-        do {
-            let data = try fileManager.get(forKey: urlString)
-            updateDiskUsageOrder(urlString: urlString)
-            return try? decoder.decode(CacheableImage.self, from: data)
-        } catch {
-            SNMLogger.error("CacheManager-imageFromDiskCache: \(error.localizedDescription) ")
-        }
-        return nil
+        try data.write(to: cacheDirectoryPath.appendingPathComponent(urlString))
+        await updateDiskUsageOrder(urlString: urlString)
+        await removeOldestDiskImage()
+        printDiskCacheDirectory()
     }
 
-    private func updateDiskUsageOrder(urlString: String) {
-        if !usageOrder.contains(urlString) {
-            usageOrder.append(urlString)
-        }
+    func loadFromDist(urlString: String) async throws -> CacheableImage? {
+        let filePath = cacheDirectoryPath.appendingPathComponent(urlString)
+        guard FileManager.default.fileExists(atPath: filePath.path) else { return nil }
 
+        let data = try Data(contentsOf: filePath)
+        await updateDiskUsageOrder(urlString: urlString)
+        return try decoder.decode(CacheableImage.self, from: data)
+    }
+
+    private func updateDiskUsageOrder(urlString: String) async {
         if let index = usageOrder.firstIndex(of: urlString) {
             usageOrder.remove(at: index)
-            usageOrder.append(urlString)
         }
+        usageOrder.append(urlString)
     }
 
-    private func removeOldestDiskImage() {
+    private func removeOldestDiskImage() async {
         SNMLogger.info("usageOrderCount: \(usageOrder.count)")
         while usageOrder.count > cacheLimit {
             guard let oldestKey = usageOrder.first else { return }
@@ -102,33 +70,74 @@ final class ImageNSCacheManager {
         }
     }
 
-    func printDiskCacheDirectory() {
-        let cacheDirectory = ImageNSCacheManager.shared.cacheDirectoryPath
-        SNMLogger.info("Disk cache directory: \(cacheDirectory.path)")
+    private func printDiskCacheDirectory() {
+        SNMLogger.info("Disk cache directory: \(cacheDirectoryPath.path)")
 
-        if let contents = try? FileManager.default.contentsOfDirectory(atPath: cacheDirectory.path) {
+        if let contents = try? FileManager.default.contentsOfDirectory(atPath: cacheDirectoryPath.path) {
             SNMLogger.info("Disk cache contents: \(contents)")
         }
     }
 }
 
+final class ImageNSCacheManager {
+    static let shared = ImageNSCacheManager()
+    
+    private let cache: NSCache<NSString, CacheableImage>
+    private let diskCacheManager: DiskCacheManager
+
+    private init(
+        cache: NSCache<NSString, CacheableImage> = NSCache<NSString, CacheableImage>()
+    ) {
+        self.cache = cache
+        let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        let diskCacheURL = cachesURL.appendingPathComponent("DownloadedCache")
+        self.diskCacheManager = DiskCacheManager(cacheDirectoryPath: diskCacheURL)
+
+        cache.totalCostLimit = 5 * 1024 * 1024 // 5MB
+    }
+    
+    func saveMemoryCache(urlString: String, cacheableImage: CacheableImage) {
+        cache.setObject(cacheableImage, forKey: urlString as NSString)
+    }
+    
+    func saveDiskCache(urlString: String, cacheableImage: CacheableImage) async {
+        do {
+            try await diskCacheManager.saveToDist(urlString: urlString, cacheableImage: cacheableImage)
+        } catch {
+            SNMLogger.error("CacheManager-saveDiskCache: \(error.localizedDescription) ")
+        }
+    }
+    
+    func imageFromMemoryCache(urlString: String) -> CacheableImage? {
+        return cache.object(forKey: urlString as NSString)
+    }
+    
+    func imageFromDiskCache(urlString: String) async -> CacheableImage? {
+        do {
+            return try await diskCacheManager.loadFromDist(urlString: urlString)
+        } catch {
+            SNMLogger.error("CacheManager-imageFromDiskCache: \(error.localizedDescription) ")
+            return nil
+        }
+    }
+}
+
 extension ImageNSCacheManager: ImageCacheable {
-    func save(urlString: String, lastModified: String?, imageData: Data?) {
+    func save(urlString: String, lastModified: String?, imageData: Data?) async {
         guard let lastModified,
               let imageData else { return }
         let cacheableImage = CacheableImage(lastModified: lastModified, imageData: imageData)
         
         saveMemoryCache(urlString: urlString, cacheableImage: cacheableImage)
-        saveDiskCache(urlString: urlString, cacheableImage: cacheableImage)
-        printDiskCacheDirectory()
+        await saveDiskCache(urlString: urlString, cacheableImage: cacheableImage)
     }
     
-    func image(urlString: String) -> CacheableImage? {
+    func image(urlString: String) async -> CacheableImage? {
         if let image = imageFromMemoryCache(urlString: urlString) { // 메모리 캐시 hit
             SNMLogger.info("memory cache hit")
             return image
         }
-        if let image = imageFromDiskCache(urlString: urlString) { // 디스크 캐시 hit
+        if let image = await imageFromDiskCache(urlString: urlString) { // 디스크 캐시 hit
             SNMLogger.info("disk cache hit")
             saveMemoryCache(urlString: urlString, cacheableImage: image)
             return image

--- a/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
@@ -35,6 +35,10 @@ final class ImageNSCacheManager {
         self.cache = cache
         self.fileManager = fileManager
         cache.totalCostLimit = 5 * 1024 * 1024 // 5MB
+
+        if let content = try? FileManager.default.contentsOfDirectory(atPath: cacheDirectoryPath.path) {
+            usageOrder = content
+        }
     }
     
     func saveMemoryCache(urlString: String, cacheableImage: CacheableImage) {
@@ -44,9 +48,11 @@ final class ImageNSCacheManager {
     func saveDiskCache(urlString: String, cacheableImage: CacheableImage) {
         do {
             let data = try encoder.encode(cacheableImage)
-            try fileManager.set(value: data, forKey: urlString)
 
-            // 디스크 캐시에 저장 후 사용 순서 업데이트
+            if !FileManager.default.fileExists(atPath: cacheDirectoryPath.path) {
+                try FileManager.default.createDirectory(at: cacheDirectoryPath, withIntermediateDirectories: true, attributes: nil)
+            }
+            try data.write(to: cacheDirectoryPath.appendingPathComponent(urlString))
             updateDiskUsageOrder(urlString: urlString)
             removeOldestDiskImage()
         } catch {
@@ -86,16 +92,22 @@ final class ImageNSCacheManager {
             guard let oldestKey = usageOrder.first else { return }
             usageOrder.removeFirst()
 
-            try? fileManager.delete(forKey: oldestKey)
+            let filePath = cacheDirectoryPath.appendingPathComponent(oldestKey)
+            do {
+                try FileManager.default.removeItem(at: filePath)
+                SNMLogger.info("Removed disk image: \(oldestKey)")
+            } catch {
+                SNMLogger.error("Failed to remove disk image: \(oldestKey): \(error)")
+            }
         }
     }
 
     func printDiskCacheDirectory() {
         let cacheDirectory = ImageNSCacheManager.shared.cacheDirectoryPath
-        print("Disk cache directory: \(cacheDirectory.path)")
+        SNMLogger.info("Disk cache directory: \(cacheDirectory.path)")
 
         if let contents = try? FileManager.default.contentsOfDirectory(atPath: cacheDirectory.path) {
-            print("Disk cache contents: \(contents)")
+            SNMLogger.info("Disk cache contents: \(contents)")
         }
     }
 }

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestProfileImageUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestProfileImageUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol RequestProfileImageUseCase {
-    func execute(fileName: String) async throws -> Data?
+    func execute(fileName: String) async -> Data?
 }
 
 struct RequestProfileImageUseCaseImpl: RequestProfileImageUseCase {
@@ -23,7 +23,7 @@ struct RequestProfileImageUseCaseImpl: RequestProfileImageUseCase {
         self.cacheManager = cacheManager
     }
 
-    func execute(fileName: String) async throws -> Data? {
+    func execute(fileName: String) async -> Data? {
         if let cacheableImage = await cacheManager.image(urlString: fileName) { // 캐시에 있을 때
             do {
                 let remoteImage = try await remoteImageManager.download(

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestProfileImageUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestProfileImageUseCase.swift
@@ -24,7 +24,7 @@ struct RequestProfileImageUseCaseImpl: RequestProfileImageUseCase {
     }
 
     func execute(fileName: String) async throws -> Data? {
-        if let cacheableImage = cacheManager.image(urlString: fileName) { // 캐시에 있을 때
+        if let cacheableImage = await cacheManager.image(urlString: fileName) { // 캐시에 있을 때
             do {
                 let remoteImage = try await remoteImageManager.download(
                     fileName: fileName,
@@ -34,7 +34,7 @@ struct RequestProfileImageUseCaseImpl: RequestProfileImageUseCase {
                     SNMLogger.log("not modified")
                     return cacheableImage.imageData
                 } else {
-                    cacheManager.save(urlString: fileName,
+                    await cacheManager.save(urlString: fileName,
                                                  lastModified: remoteImage.lastModified,
                                                  imageData: remoteImage.imageData)
                     return remoteImage.imageData!
@@ -49,7 +49,7 @@ struct RequestProfileImageUseCaseImpl: RequestProfileImageUseCase {
                     fileName: fileName,
                     lastModified: ""
                 )
-                cacheManager.save(urlString: fileName,
+                await cacheManager.save(urlString: fileName,
                                              lastModified: remoteImage.lastModified,
                                              imageData: remoteImage.imageData)
                 return remoteImage.imageData

--- a/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Router/RequestWalkRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Router/RequestWalkRouter.swift
@@ -49,7 +49,7 @@ extension RequestWalkRouter: RequestWalkBuildable {
         RequestProfileImageUseCase = RequestProfileImageUseCaseImpl(
             remoteImageManager: SupabaseStorageManager(
             networkProvider: SNMNetworkProvider()),
-            cacheManager: ImageNSCacheManager.shared
+            cacheManager: CacheManager.shared
         )
         let loadInfoUseCase: LoadUserInfoUseCase = LoadUserInfoUseCaseImpl(
             dataLoadable: LocalDataManager(),

--- a/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Router/ProcessedWalkRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Router/ProcessedWalkRouter.swift
@@ -43,7 +43,7 @@ extension ProcessedWalkModuleBuildable {
                 remoteImageManager: SupabaseStorageManager(
                     networkProvider: SNMNetworkProvider()
                 ),
-                cacheManager: ImageNSCacheManager.shared
+                cacheManager: CacheManager.shared
             )
         )
         let router = ProcessedWalkRouter()

--- a/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Router/RespondWalkRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Router/RespondWalkRouter.swift
@@ -44,7 +44,7 @@ RequestProfileImageUseCaseImpl(
             remoteImageManager: SupabaseStorageManager(
                 networkProvider: SNMNetworkProvider()
             ),
-            cacheManager: ImageNSCacheManager.shared
+            cacheManager: CacheManager.shared
         )
         let loadUserUseCase = LoadUserInfoUseCaseImpl(
             dataLoadable: LocalDataManager(),


### PR DESCRIPTION
### 🔖  Issue Number

close #21 
close #13 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] 디스크 캐시에 캐시 정책 적용
- [x] 디스크 캐시 파일 입출력 비동기 처리하기
- [x] 캐시 정책에 배열이 아닌 OrderedSet 사용해 시간복잡도 개선하기


### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 특이 사항 1
메모리 캐시는 NSCache 이용해 자동 정책이 적용되기 때문에 디스크 캐시에만 정책을 추가하였습니다.
정책의 기준은 데이터의 개수로 잡았습니다. 이미지를 다운샘플링해서 저장하기 때문에 용량으로 제한하지 않아도 용량 문제가 발생하지 않을 것이라고 판단했기 때문입니다.

- 특이 사항 2
Swift Collections를 SPM에서 다운받아 OrderedSet을 사용하는 과정에서 테스트 오류가 발생했습니다.
CI 테스트에서 Linker 오류가 발생하며 초기에 PersistenceTest를 실패하였습니다. Host Application을 변경하고 해당 테스트 코드 프레임워크로 추가하고 나니 CI 테스트 통과되었습니다.

### 👻 레퍼런스
