### PR TITLE
[refactor] 프로필 등록 시점에 멀티스레딩 적용

### DIFF
--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
@@ -37,7 +37,6 @@ final class ProfileCreateInteractor: ProfileCreateInteractable {
 
     func signInWithProfileData(dogInfo: UserInfo, imageData: (png: Data?, jpg: Data?)) {
         Task {
-            let state = SNMLogger.begin(name: "RegisterProfile")
             do {
                 try await SupabaseAuthManager.shared.signInAnonymously()
                 let fileName = try await withThrowingTaskGroup(of: String?.self) { group in
@@ -59,13 +58,13 @@ final class ProfileCreateInteractor: ProfileCreateInteractable {
                             return try await self.saveProfileImageUseCase.execute(imageData: jpgData)
                         }
                     }
-                    var uploadedFileName: String? = nil
+                    var savedFileName: String? = nil
                     for try await result in group {
                         if let name = result {
-                            uploadedFileName = name
+                            savedFileName = name
                         }
                     }
-                    return uploadedFileName
+                    return savedFileName
                 }
 
                 guard let userID = SessionManager.shared.session?.user?.userID else {
@@ -88,10 +87,6 @@ final class ProfileCreateInteractor: ProfileCreateInteractable {
             } catch {
                 presenter?.didFailToSaveUserInfo(error: error)
             }
-            defer {
-                SNMLogger.end(name: "RegisterProfile", state: state) // begin과 동일 name
-            }
-            print("RegisterProfile")
         }
     }
     func convertImageToPNGData(image: UIImage?) -> Data? {

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
@@ -39,7 +39,7 @@ final class ProfileCreateInteractor: ProfileCreateInteractable {
         Task {
             do {
                 try await SupabaseAuthManager.shared.signInAnonymously()
-                try saveUserInfoUseCase.execute(dog: UserInfo(
+                async let saveUserInfoTask =  saveUserInfoUseCase.execute(dog: UserInfo(
                     name: dogInfo.name,
                     age: dogInfo.age,
                     sex: dogInfo.sex,
@@ -49,12 +49,15 @@ final class ProfileCreateInteractor: ProfileCreateInteractable {
                     nickname: dogInfo.nickname,
                     profileImage: imageData.png)
                 )
-                var fileName: String? = nil
-                if let jpgData = imageData.jpg {
-                    fileName = try await saveProfileImageUseCase.execute(
+                async let fileNameTask: String? = {
+                    guard let jpgData = imageData.jpg else { return nil }
+                    return try await saveProfileImageUseCase.execute(
                         imageData: jpgData
                     )
-                }
+                }()
+
+                let (userResult, fileName) = try await (saveUserInfoTask, fileNameTask)
+
                 guard let userID = SessionManager.shared.session?.user?.userID else {
                     return
                 }

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
@@ -37,6 +37,7 @@ final class ProfileCreateInteractor: ProfileCreateInteractable {
 
     func signInWithProfileData(dogInfo: UserInfo, imageData: (png: Data?, jpg: Data?)) {
         Task {
+            let state = SNMLogger.begin(name: "RegisterProfile")
             do {
                 try await SupabaseAuthManager.shared.signInAnonymously()
                 async let saveUserInfoTask =  saveUserInfoUseCase.execute(dog: UserInfo(
@@ -78,6 +79,10 @@ final class ProfileCreateInteractor: ProfileCreateInteractable {
             } catch {
                 presenter?.didFailToSaveUserInfo(error: error)
             }
+            defer {
+                SNMLogger.end(name: "RegisterProfile", state: state)
+            }
+            print("RegisterProfile")
         }
     }
     func convertImageToPNGData(image: UIImage?) -> Data? {

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
@@ -39,9 +39,9 @@ final class ProfileCreateInteractor: ProfileCreateInteractable {
         Task {
             do {
                 try await SupabaseAuthManager.shared.signInAnonymously()
-                let fileName = try await withThrowingTaskGroup(of: String?.self) { group in
+                let fileName = try await withThrowingTaskGroup(of: String?.self) { [weak self] group in
                     group.addTask {
-                        try self.saveUserInfoUseCase.execute(dog: UserInfo(
+                        try self?.saveUserInfoUseCase.execute(dog: UserInfo(
                             name: dogInfo.name,
                             age: dogInfo.age,
                             sex: dogInfo.sex,
@@ -55,7 +55,7 @@ final class ProfileCreateInteractor: ProfileCreateInteractable {
                     }
                     if let jpgData = imageData.jpg {
                         group.addTask {
-                            return try await self.saveProfileImageUseCase.execute(imageData: jpgData)
+                            return try await self?.saveProfileImageUseCase.execute(imageData: jpgData)
                         }
                     }
                     var savedFileName: String? = nil

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
@@ -40,24 +40,33 @@ final class ProfileCreateInteractor: ProfileCreateInteractable {
             let state = SNMLogger.begin(name: "RegisterProfile")
             do {
                 try await SupabaseAuthManager.shared.signInAnonymously()
-                async let saveUserInfoTask =  saveUserInfoUseCase.execute(dog: UserInfo(
-                    name: dogInfo.name,
-                    age: dogInfo.age,
-                    sex: dogInfo.sex,
-                    sexUponIntake: dogInfo.sexUponIntake,
-                    size: dogInfo.size,
-                    keywords: dogInfo.keywords,
-                    nickname: dogInfo.nickname,
-                    profileImage: imageData.png)
-                )
-                async let fileNameTask: String? = {
-                    guard let jpgData = imageData.jpg else { return nil }
-                    return try await saveProfileImageUseCase.execute(
-                        imageData: jpgData
-                    )
-                }()
-
-                let (userResult, fileName) = try await (saveUserInfoTask, fileNameTask)
+                let fileName = try await withThrowingTaskGroup(of: String?.self) { group in
+                    group.addTask {
+                        try self.saveUserInfoUseCase.execute(dog: UserInfo(
+                            name: dogInfo.name,
+                            age: dogInfo.age,
+                            sex: dogInfo.sex,
+                            sexUponIntake: dogInfo.sexUponIntake,
+                            size: dogInfo.size,
+                            keywords: dogInfo.keywords,
+                            nickname: dogInfo.nickname,
+                            profileImage: imageData.png)
+                        )
+                        return nil
+                    }
+                    if let jpgData = imageData.jpg {
+                        group.addTask {
+                            return try await self.saveProfileImageUseCase.execute(imageData: jpgData)
+                        }
+                    }
+                    var uploadedFileName: String? = nil
+                    for try await result in group {
+                        if let name = result {
+                            uploadedFileName = name
+                        }
+                    }
+                    return uploadedFileName
+                }
 
                 guard let userID = SessionManager.shared.session?.user?.userID else {
                     return
@@ -80,7 +89,7 @@ final class ProfileCreateInteractor: ProfileCreateInteractable {
                 presenter?.didFailToSaveUserInfo(error: error)
             }
             defer {
-                SNMLogger.end(name: "RegisterProfile", state: state)
+                SNMLogger.end(name: "RegisterProfile", state: state) // begin과 동일 name
             }
             print("RegisterProfile")
         }


### PR DESCRIPTION
### 🔖  Issue Number

close #25

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] async let 이용해 멀티스레딩 적용
- [x] Task Group 이용해 멀티스레딩 적용
- [x] OSSignPoster 이용해 시간 지연 측정


### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 멀티스레딩 적용
현재 signInWithProfileData() 함수에서는 아래 4개의 함수가 하나의 스레드에서 순차적으로 실행되고 있었습니다.
  - await SupabaseAuthManager.shared.signInAnonymously()
  - try saveUserInfoUseCase.execute()
  - try await saveProfileImageUseCase.execute()
  - await saveUserInfoRemoteUseCase.execute()
위 함수들은 순서가 보장되어야 하는 부분이 있기 때문에, 동시에 작업 가능한 로컬에 사용자 정보 저장하기와 이미지 저장을 하나의 Task Group으로 묶었습니다.

- OSSignPoster 시간지연 측정
프로필 정보 전부 통일 시켜서 각각 기존 코드(멀티스레딩X), async let, Task Group 사용시 시간 지연을 측정했습니다.
1차 시도 - 기존 : 2.98 / async let : 2.55 / Task Group : 1.68
2차 시도 - 기존 : 2.50 / async let : 1.85 / Task Group : 1.75
위 측정 결과로 보아 Task Group 멀티스레딩 적용 시점에 시간이 줄어든것을 확인할 수 있었고 최종적용했습니다.

