### PR TITLE
[fix] 디폴트 메이트 프로젝트가 아닌 Supabase단에서 처리하도록 수정

### DIFF
--- a/SniffMeet/SniffMeet/Source/DTO/MateListDTO.swift
+++ b/SniffMeet/SniffMeet/Source/DTO/MateListDTO.swift
@@ -10,12 +10,7 @@ import Foundation
 /// 처음 회원가입할 때는 메이트가 없으므로 빈 배열로 고정했습니다.
 struct MateListInsertDTO: Encodable {
     let id: UUID
-    let mates: [UUID] = [
-        UUID(uuidString: "f27c02f6-0110-4291-b866-a1ead0742755") ?? .init(),
-        UUID(uuidString: "b79bc6b9-b776-4f5b-8f6c-48ba498b6e3a") ?? .init(),
-        UUID(uuidString: "bda7ec28-1407-4871-93ea-c7835986726a") ?? .init(),
-        UUID(uuidString: "a96ee934-03b9-43f3-b29b-53c3ba945363") ?? .init()
-    ]
+    let mates: [UUID]?
     enum CodingKeys: String, CodingKey {
         case id, mates
     }

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/CreateAccountUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/CreateAccountUseCase.swift
@@ -26,7 +26,7 @@ struct CreateAccountUseCaseImpl: CreateAccountUseCase {
             SNMLogger.error("\(error.localizedDescription)")
         }
         do {
-            let mateListData = try encoder.encode(MateListInsertDTO(id: info.id))
+            let mateListData = try encoder.encode(MateListInsertDTO(id: info.id, mates: nil))
             try await SupabaseDatabaseManager.shared.insertData(
                 into: Environment.SupabaseTableName.matelist,
                 with: mateListData


### PR DESCRIPTION
- MateListInsertDTO에서 mates 배열을 옵셔널로 처리했습니다.

### 🔖  Issue Number

close #33

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- MateListDTO가 디폴트 메이트를 넘겨주지 않도록 수정했습니다.
- 앞으로 디폴트 메이트를 추가/변경할 때 Supabase SQL 쿼리로 쉽게 변경 가능합니다. (Supabase에 쿼리가 저장되어있습니다)
<img width="661" alt="Screenshot 2025-01-23 at 11 16 48 AM" src="https://github.com/user-attachments/assets/86bd6436-6185-4aab-aff5-d6e93fb1c006" />


